### PR TITLE
Tree-level SMEFT Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# debug information files
+*.dwo
+
+# build
+build/
+CMakeFiles/
+examples/CMakeFiles/
+*Makefile
+*cmake_install.cmake
+*CMakeCache.txt
+
+# other
+*.tar.gz
+.vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.8...3.20)
 project(griffin VERSION 1.0
                 LANGUAGES CXX)
 
-add_library(griffin STATIC classes.cc ff.cc EWPOZ.cc EWPOZ2.cc deltar.cc
-                delrho.cc xscnnlo.cc xscaas.cc B0.cc C0.cc D0.cc li.cc linex.cc 
-		tools.cc classes.h ff0.h ff.h EWPOZ.h EWPOZ2.h deltar.h delrho.h 
-		xscnnlo.h xscaas.h oneloop.h li.h linex.h tools.h)
+add_library(griffin STATIC classes.cc ff.cc EWPOZ.cc EWPOZ2.cc EWPOZSMEFT.cc deltar.cc deltarSMEFT.cc
+                delrho.cc xscnnlo.cc xscSMEFT.cc xscaas.cc B0.cc C0.cc D0.cc li.cc linex.cc 
+		tools.cc classes.h ff0.h ff.h EWPOZ.h EWPOZ2.h EWPOZSMEFT.h deltar.h deltarSMEFT.h delrho.h 
+		xscnnlo.h xscSMEFT.h xscaas.h oneloop.h li.h linex.h tools.h)
 
 target_compile_features(griffin PUBLIC cxx_std_11)
 set_target_properties(griffin PROPERTIES CXX_EXTENSIONS OFF)

--- a/EWPOZSMEFT.cc
+++ b/EWPOZSMEFT.cc
@@ -15,12 +15,13 @@ namespace griffin {
 
 Cplx SW_SMEFTLO::resSMEFTLO(void) const
 {
-  return(-vz0(ftyp,*ival)/(4*fabs(Qf[ftyp])*az0(ftyp,*ival))*(fabs(2*az0(ftyp, *ival))*z0SMEFT(ftyp,VEC,*ival)/vz0(ftyp,*ival)-fabs(2*az0(ftyp, *ival))*z0SMEFT(ftyp,AXV,*ival)/az0(ftyp,*ival))); //remove minus sign to align with convention?
+  return(-vz0(ftyp,*ival)/(4*fabs(Qf[ftyp])*az0(ftyp,*ival))*(z0SMEFT(ftyp,VEC,*ival)/vz0(ftyp,*ival)-z0SMEFT(ftyp,AXV,*ival)/az0(ftyp,*ival))); // delta sin(theta_{f,eff}) = -1/(4|Q_f|)v_f(0)^Z/a_f(0)^Z(delta v_f/v_f(0)^Z-delta a_f/a_f(0)^Z).
+                                                                                                                                                 // z0SMEFT calculates these deltas, which are el/(2*sw*cw)*(delta g_L^{Zf} +/- delta g_R^{Zf})
 }
 
 Cplx FA_SMEFTLO::resSMEFTLO(void) const
 {
-  return(2*fabs(az0(ftyp,*ival))*fabs(z0SMEFT(ftyp,AXV,*ival)));
+  return(2*fabs(az0(ftyp,*ival))*fabs(z0SMEFT(ftyp,AXV,*ival))); // In the SMEFT, F_A^f = |a_f^Z|^2 ~ |a_f(0)^Z|^2+2|delta a_f||a_f(0)^Z| 
 }
 
 Cplx FV_SMEFTLO::result(void) const

--- a/EWPOZSMEFT.cc
+++ b/EWPOZSMEFT.cc
@@ -1,0 +1,32 @@
+/*-----------------------------------------------------------------------------
+EWPOZSMEFT.cc
+Lisong Chen (lic114@pitt.edu), Ayres Freitas (afreitas@pitt.edu), Jackson Wallace (ejw108@pitt.edu)
+last revision: 17 Feb 2026
+-------------------------------------------------------------------------------
+classes for F_A and sw_eff form factors with SMEFT LO corrections
+-----------------------------------------------------------------------------*/
+
+#include "EWPOZSMEFT.h"
+#include "ff0.h"
+#include "ff.h"
+#include "oneloop.h"
+
+namespace griffin {
+
+Cplx SW_SMEFTLO::resSMEFTLO(void) const
+{
+  return(-vz0(ftyp,*ival)/(4*fabs(Qf[ftyp])*az0(ftyp,*ival))*(fabs(2*az0(ftyp, *ival))*z0SMEFT(ftyp,VEC,*ival)/vz0(ftyp,*ival)-fabs(2*az0(ftyp, *ival))*z0SMEFT(ftyp,AXV,*ival)/az0(ftyp,*ival))); //remove minus sign to align with convention?
+}
+
+Cplx FA_SMEFTLO::resSMEFTLO(void) const
+{
+  return(2*fabs(az0(ftyp,*ival))*fabs(z0SMEFT(ftyp,AXV,*ival)));
+}
+
+Cplx FV_SMEFTLO::result(void) const
+{
+  double QVf = 1-4*fabs(Qf[ftyp])*realreg(sw->result());
+  return(fa->result()*(QVf*QVf));
+}
+
+} // namespace

--- a/EWPOZSMEFT.h
+++ b/EWPOZSMEFT.h
@@ -1,0 +1,48 @@
+/* EWPOZSMEFT.h: header file for EWPOZ2.cc */
+
+#ifndef __EWPOZMSEFT__
+#define __EWPOZSMEFT__
+
+#include "EWPOZ2.h"
+#include "delrho.h"
+
+namespace griffin {
+
+// effective weak mixing angle predicted in the SMEFT (at LO)
+class SW_SMEFTLO : public SW_SMNNLO { //make a template that can choose which order of SM to use with SMEFT
+public:
+  using SW_SMNNLO::SW_SMNNLO;
+  Cplx resSMEFTLO(void) const;  // tree-level SMEFT corrections
+  Cplx result(void) const
+  {
+    return(SW_SMNNLO::result()+resSMEFTLO()); //want all orders of the SM
+  }
+};
+
+// axial-vector form factor predicted in the SMEFT (at LO)
+class FA_SMEFTLO : public FA_SMNNLO {
+public:
+  using FA_SMNNLO::FA_SMNNLO;
+  Cplx resSMEFTLO(void) const;  // tree-level SMEFT corrections
+  Cplx result(void) const
+  {
+    return(FA_SMNNLO::result()+resSMEFTLO());
+  }
+};
+
+// vector form factor predicted in the SMEFT (at LO); computed from F_A and sw_eff
+class FV_SMEFTLO : public FV_SMNNLO {
+public:
+  FV_SMEFTLO(const int type, const inval& input) : FV_SMNNLO(type, input)
+  {
+//    ftyp = type;
+    fa = new FA_SMEFTLO(type, input);
+    sw = new SW_SMEFTLO(type, input);
+  }
+
+  Cplx result(void) const;
+};
+
+} // namespace
+
+#endif // __EWPOZMSEFT__

--- a/EWPOZSMEFT.h
+++ b/EWPOZSMEFT.h
@@ -9,13 +9,13 @@
 namespace griffin {
 
 // effective weak mixing angle predicted in the SMEFT (at LO)
-class SW_SMEFTLO : public SW_SMNNLO { //make a template that can choose which order of SM to use with SMEFT
+class SW_SMEFTLO : public SW_SMNNLO {
 public:
   using SW_SMNNLO::SW_SMNNLO;
   Cplx resSMEFTLO(void) const;  // tree-level SMEFT corrections
   Cplx result(void) const
   {
-    return(SW_SMNNLO::result()+resSMEFTLO()); //want all orders of the SM
+    return(SW_SMNNLO::result()+resSMEFTLO());
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # GRIFFIN  
-GRIFFIN (Gauge-invariant Resonance In Four-Fermion INteractions), is an object-oriented C++ library for electroweak radiative corrections, provides a modular framework of describing 2-to-2 fermion scattering processes with specific attention to a consistent gauge-invariant description of the gauge-boson resonance. Version 1.1 of this library provides Standard Model predictions for the 2-to-2 fermion processes with full NNLO and leading higher-order contributions on the Z-resonance, NLO + O(αα<sub>s</sub>) off the Z-resonance, and NLO Bhabha scattering.
+GRIFFIN (Gauge-invariant Resonance In Four-Fermion INteractions), as an object-oriented C++ library for electroweak radiative corrections, provides a modular framework of describing 2-to-2 fermion scattering processes with specific attention to a consistent gauge-invariant description of the gauge-boson resonance. Version 1.1 of this library provides Standard Model predictions for the 2-to-2 fermion processes with full NNLO and leading higher-order contributions on the Z-resonance, NLO + O(αα<sub>s</sub>) off the Z-resonance, and NLO Bhabha scattering.
 
 # Download and Installation
-One can download the released version 1.1 from [here](https://github.com/lisongc/GRIFFIN/releases/tag/v1.1)
+One can download the released version 1.1 from [here](https://github.com/lisongc/GRIFFIN/releases/tag/v1.1.0).
+
 To compile GRIFFIN into a link library using the cmake build system, run the commands
 
 ```bash

--- a/SMEFTval.h
+++ b/SMEFTval.h
@@ -40,7 +40,7 @@ public:
   SMEFTval(void) : SMEFTval(SIZE1) {};
   SMEFTval(const inval& copyfrom) : SMval(copyfrom), dataSMEFT(SIZE1, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
 
-  //set Wilson coefficient values
+  // set Wilson coefficient values
   void set(const int idx, const double val) override
   {
     if(idx < data.size() & idx > 29)
@@ -83,7 +83,7 @@ public:
     compute();
   }
 
-  //get Wilson coefficient values
+  // get Wilson coefficient values
   double get(const int idx) const override
   {
     if(idx < data.size() & idx > 29)

--- a/SMEFTval.h
+++ b/SMEFTval.h
@@ -1,0 +1,135 @@
+/* SMEFTval.h: define input class that includes values for Wilsonian SMEFT coeffs */
+
+#ifndef __SMEFTval__
+#define __SMEFTval__
+
+#include "classes.h"
+#include "SMval.h"
+
+namespace griffin {
+// define indices for the Wilson coeffs
+
+#define CphiD     30
+#define CphiWB    31    
+#define Cphil1    32 
+#define Cphil3    33   
+#define Cphie     34  
+#define Cphiq1    35  
+#define Cphiq3    36  
+#define Cphiu     37
+#define Cphid     38
+#define Cll       39
+#define Clq1      40
+#define Clq3      41
+#define Cee       42
+#define Ceu       43
+#define Ced       44  
+#define Cle       45
+#define Clu       46
+#define Cld       47
+#define Cqe       48
+
+class SMEFTval : public SMval {
+protected:
+  vector<vector<vector<vector<vector<double>>>>> dataSMEFT;
+public:
+  using SMval::SMval;
+  using SMval::set;
+  using SMval::get;
+  SMEFTval(const int sizealloc) : dataSMEFT(sizealloc, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
+  SMEFTval(void) : SMEFTval(SIZE1) {};
+  SMEFTval(const inval& copyfrom) : SMval(copyfrom), dataSMEFT(SIZE1, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
+
+  //set Wilson coefficient values
+  void set(const int idx, const double val) override
+  {
+    if(idx < data.size() & idx > 29)
+      dataSMEFT[idx][0][0][0][0] = val;
+    else if(idx < data.size()){
+      data[idx] = val;
+    } else
+    {
+      cerr << "Input value index " << idx << " outside of range" << endl;
+      exit(1);
+    }
+    compute();
+  }
+  
+  void set(const int idx, const double val, const int gen1, const int gen2)
+  {
+    if(idx < data.size() & idx > 29)
+      dataSMEFT[idx][gen1-1][gen2-1][0][0] = val;
+    else if(idx < data.size()){
+      data[idx] = val;
+    } else
+    {
+      cerr << "Input value index " << idx << " outside of range" << endl;
+      exit(1);
+    }
+    compute();
+  }
+  
+  void set(const int idx, const double val, const int gen1, const int gen2, const int gen3, const int gen4)
+  {
+    if(idx < data.size() & idx > 29)
+      dataSMEFT[idx][gen1-1][gen2-1][gen3-1][gen4-1] = val;
+    else if(idx < data.size()){
+      data[idx] = val;
+    } else
+    {
+      cerr << "Input value index " << idx << " outside of range" << endl;
+      exit(1);
+    }
+    compute();
+  }
+
+  //get Wilson coefficient values
+  double get(const int idx) const override
+  {
+    if(idx < data.size() & idx > 29)
+    {
+      if(isfinite(dataSMEFT[idx][0][0][0][0]))
+        return(dataSMEFT[idx][0][0][0][0]);
+    } else
+    {
+      if(isfinite(data[idx]))
+        return(data[idx]); 
+    }
+    cerr << "Invalid or undefined input value for index " << idx << endl;
+    exit(1);
+  }
+
+  double get(const int idx, const int gen1, const int gen2) const override
+  {
+    if(idx < data.size() & idx > 29)
+    {
+      if(isfinite(dataSMEFT[idx][gen1-1][gen2-1][0][0]))
+        return(dataSMEFT[idx][gen1-1][gen2-1][0][0]);
+    } else
+    {
+      if(isfinite(data[idx]))
+        return(data[idx]); 
+    }
+    cerr << "Invalid or undefined input value for index " << idx << endl;
+    exit(1);
+  }
+  
+  double get(const int idx, const int gen1, const int gen2, const int gen3, const int gen4) const override
+  {
+    if(idx < data.size() & idx > 29)
+    {
+      if(isfinite(dataSMEFT[idx][gen1-1][gen2-1][gen3-1][gen4-1]))
+        return(dataSMEFT[idx][gen1-1][gen2-1][gen3-1][gen4-1]);
+    } else
+    {
+      if(isfinite(data[idx]))
+        return(data[idx]); 
+    }
+    cerr << "Invalid or undefined input value for index " << idx << endl;
+    exit(1);
+  }
+};
+
+} // namespace
+
+#endif // __SMEFTval__

--- a/SMEFTvalG.h
+++ b/SMEFTvalG.h
@@ -1,0 +1,32 @@
+// will want to use SMEFT inputs, then set Cll/Cphil3 to 0
+/* SMEFTvalG.h: define input class that includes values for Wilsonian SMEFT coeffs using G_mu as input */
+
+#ifndef __SMEFTvalG__
+#define __SMEFTvalG__
+
+#include "deltarSMEFT.h"
+#include "SMvalG.h"
+
+namespace griffin {
+
+class SMEFTvalGmu : public invalGmuSMEFT {
+protected: 
+  void compute(void)
+  {
+    data[MZc] = data[MZ]/sqrt(1+sqr(data[GamZ]/data[MZ]));
+    data[GZc] = data[GamZ]/sqrt(1+sqr(data[GamZ]/data[MZ]));
+    invalGmuSMEFT::compute();
+    data[GWc] = 0.3376186*data[Gmu]*powint(data[MWc],3)*
+    		 (1+ 0.2122066*data[als]);
+    data[MW] = data[MWc]*sqrt(1+sqr(data[GWc]/data[MWc]));
+    data[GamW] = data[GWc]*sqrt(1+sqr(data[GWc]/data[MWc]));
+  }
+public:
+  using invalGmuSMEFT::invalGmuSMEFT;
+  SMEFTvalGmu(void) : invalGmuSMEFT(SIZE1) {};
+  SMEFTvalGmu(const inval& copyfrom) : invalGmuSMEFT(copyfrom) { compute(); };
+};
+
+} // namespace
+
+#endif // __SMEFTvalG__

--- a/SMEFTvalG.h
+++ b/SMEFTvalG.h
@@ -1,4 +1,3 @@
-// will want to use SMEFT inputs, then set Cll/Cphil3 to 0
 /* SMEFTvalG.h: define input class that includes values for Wilsonian SMEFT coeffs using G_mu as input */
 
 #ifndef __SMEFTvalG__

--- a/classes.h
+++ b/classes.h
@@ -48,8 +48,8 @@ public:
  
   unsigned int getsize() const
   { return data.size(); }
-     
-  void set(const int idx, const double val)  
+   
+  virtual void set(const int idx, const double val)  
   {
     if(idx < data.size())
       data[idx] = val;
@@ -60,13 +60,33 @@ public:
     }
     compute();
   }
-  
-  double get(const int idx) const
+
+  virtual double get(const int idx) const
   {
     if(idx < data.size())
     {
       if(isfinite(data[idx]))
         return(data[idx]);
+    }
+    cerr << "Invalid or undefined input value for index " << idx << endl;
+    exit(1);
+  }
+
+  virtual double get(const int idx, const int gen1, const int gen2) const
+  {
+    if(idx < data.size())
+    {
+      return 0;
+    }
+    cerr << "Invalid or undefined input value for index " << idx << endl;
+    exit(1);
+  }
+
+  virtual double get(const int idx, const int gen1, const int gen2, const int gen3, const int gen4) const
+  {
+    if(idx < data.size())
+    {
+      return 0;
     }
     cerr << "Invalid or undefined input value for index " << idx << endl;
     exit(1);

--- a/deltar.cc
+++ b/deltar.cc
@@ -113,7 +113,7 @@ void invalGmu::compute(void)
   double MWsold = 0, MWscalc = 80*80;
   double MZs = sqr(data[MZ]), GF = data[Gmu], alpha = data[al];
   dr_SMNNLO dr(*this);
-    
+  
   if(isfinite(data[MZ]*data[MH]*data[MT]*data[MB]*data[al]*data[als]
               *data[Delal]*data[Gmu])) // only proceed if all parameters needed
 	                               // for Delta_r are set

--- a/deltarSMEFT.cc
+++ b/deltarSMEFT.cc
@@ -1,0 +1,51 @@
+/*-----------------------------------------------------------------------------
+deltar.cc
+Ayres Freitas (afreitas@pitt.edu)
+last revision: 16 Feb 2022
+-------------------------------------------------------------------------------
+classes for the correction (\Delta r) to the Fermi constant in the SM; 
+as well as input class that computes M_W from G_Fermi
+-----------------------------------------------------------------------------*/
+
+#include "deltarSMEFT.h"
+
+namespace griffin {
+
+double dr_SMEFTLO::resSMEFT(void) const
+{
+  double Lambdas = sqr(246),
+         CLL0 = ival->get(Cll,1,2,2,1),
+         CLL1 = ival->get(Cll,2,1,1,2),
+         CPHIL30 = ival->get(Cphil3,1,1),
+         CPHIL31 = ival->get(Cphil3,2,2),
+         CPHIWB = ival->get(CphiWB),
+         CPHID = ival->get(CphiD),
+         ALPHA = ival->get(al),
+         MZs = sqr(ival->get(MZ)),
+         GMU = ival->get(Gmu);
+  double cos2sin2 = Pi*ALPHA/(sqrt(2)*GMU*MZs);
+  return(1/(Lambdas*GMU)*((CLL0+CLL1)/(2*sqrt(2))-(CPHIL30+CPHIL31)*sqrt(2)/2-sqrt(2)*Pi*ALPHA*CPHIWB/(sqrt(sqrt(2)*GMU*MZs*Pi*ALPHA)*(0.5-sqrt(0.25-cos2sin2)))+CPHID*(1-1/cos2sin2*(0.5+sqrt(0.25-cos2sin2)))/(2*sqrt(2))));
+}
+
+
+void invalGmuSMEFT::compute(void)
+{
+  double MWsold = 0, MWscalc = 80*80;
+  double MZs = sqr(data[MZ]), GF = data[Gmu], alpha = data[al];
+  dr_SMEFTLO dr(*this);
+
+  if(isfinite(data[MZ]*data[MH]*data[MT]*data[MB]*data[al]*data[als]*data[Delal]*data[Gmu]
+    *dataSMEFTG[Cll][0][1][1][0]*dataSMEFTG[Cll][1][0][0][1]*dataSMEFTG[Cphil3][0][0][0][0]*dataSMEFTG[Cphil3][1][1][0][0]*dataSMEFTG[CphiD][0][0][0][0]*dataSMEFTG[CphiWB][0][0][0][0])) // only proceed if all parameters needed
+	                                                                                                                         // for Delta_r are set
+  {
+    while(fabs(MWscalc-MWsold) > 1e-4)  // demand keV technical precision for m_W
+    {
+      MWsold = MWscalc;
+      data[MW] = sqrt(MWscalc);
+      MWscalc = MZs * (0.5 + sqrt(0.25 - 2.221441469079183*alpha/(GF*MZs) 
+    			  * (1+real(dr.result()))));
+    }
+  }
+}
+
+} // namespace

--- a/deltarSMEFT.cc
+++ b/deltarSMEFT.cc
@@ -1,10 +1,10 @@
 /*-----------------------------------------------------------------------------
-deltar.cc
-Ayres Freitas (afreitas@pitt.edu)
-last revision: 16 Feb 2022
+deltarSMEFT.cc
+Ayres Freitas (afreitas@pitt.edu), E. Jackson Wallace (ejw108@pitt.edu)
+last revision: 11 Jun 2026
 -------------------------------------------------------------------------------
-classes for the correction (\Delta r) to the Fermi constant in the SM; 
-as well as input class that computes M_W from G_Fermi
+classes for the correction to the W mass constant at LO in the SMEFT; 
+as well as input class that computes M_W from G_Fermi and other corrections
 -----------------------------------------------------------------------------*/
 
 #include "deltarSMEFT.h"
@@ -23,9 +23,9 @@ double dr_SMEFTLO::resSMEFT(void) const
          ALPHA = ival->get(al),
          MZs = sqr(ival->get(MZ)),
          GMU = ival->get(Gmu);
-  double cos2sin2 = Pi*ALPHA/(sqrt(2)*GMU*MZs);
-  return(1/(Lambdas*GMU)*((CLL0+CLL1)/(2*sqrt(2))-(CPHIL30+CPHIL31)*sqrt(2)/2-sqrt(2)*Pi*ALPHA*CPHIWB/(sqrt(sqrt(2)*GMU*MZs*Pi*ALPHA)*(0.5-sqrt(0.25-cos2sin2)))+CPHID*(1-1/cos2sin2*(0.5+sqrt(0.25-cos2sin2)))/(2*sqrt(2))));
-}
+  double cos2sin2 = Pi*ALPHA/(sqrt(2)*GMU*MZs); // cos^2(theta_W)*sin^2(theta_W)
+  return(cos2sin2/(GMU*Lambdas)/(2*sqrt(0.25-cos2sin2))*((CLL0+CLL1)/(2*sqrt(2))-sqrt(2)*(CPHIL30+CPHIL31)/2.-sqrt(2)*Pi*ALPHA*CPHIWB/(sqrt(sqrt(2)*GMU*MZs*Pi*ALPHA)*(0.5-sqrt(0.25-cos2sin2)))+CPHID/(2*sqrt(2))*(1-1/cos2sin2*(0.5+sqrt(0.25-cos2sin2)))));
+} // expression derived from 1502.02570 (2.15)
 
 
 void invalGmuSMEFT::compute(void)
@@ -36,14 +36,14 @@ void invalGmuSMEFT::compute(void)
 
   if(isfinite(data[MZ]*data[MH]*data[MT]*data[MB]*data[al]*data[als]*data[Delal]*data[Gmu]
     *dataSMEFTG[Cll][0][1][1][0]*dataSMEFTG[Cll][1][0][0][1]*dataSMEFTG[Cphil3][0][0][0][0]*dataSMEFTG[Cphil3][1][1][0][0]*dataSMEFTG[CphiD][0][0][0][0]*dataSMEFTG[CphiWB][0][0][0][0])) // only proceed if all parameters needed
-	                                                                                                                         // for Delta_r are set
+    // for Delta_r are set
   {
     while(fabs(MWscalc-MWsold) > 1e-4)  // demand keV technical precision for m_W
     {
       MWsold = MWscalc;
       data[MW] = sqrt(MWscalc);
       MWscalc = MZs * (0.5 + sqrt(0.25 - 2.221441469079183*alpha/(GF*MZs) 
-    			  * (1+real(dr.result()))));
+    			  * (1+real(dr.result())))+dr.resSMEFT());
     }
   }
 }

--- a/deltarSMEFT.h
+++ b/deltarSMEFT.h
@@ -1,0 +1,150 @@
+/* deltar.h: header file for deltar.cc */
+
+#ifndef __deltarSMEFT__
+#define __deltarSMEFT__
+
+#include "deltar.h"
+
+// define indices for the Wilson coeffs
+
+#define CphiD     30
+#define CphiWB    31    
+#define Cphil1    32 
+#define Cphil3    33   
+#define Cphie     34  
+#define Cphiq1    35  
+#define Cphiq3    36  
+#define Cphiu     37
+#define Cphid     38
+#define Cll       39
+#define Clq1      40
+#define Clq3      41
+#define Cee       42
+#define Ceu       43
+#define Ced       44  
+#define Cle       45
+#define Clu       46
+#define Cld       47
+#define Cqe       48
+
+namespace griffin {
+
+// Delta r predicted in the SMEFT (at LO) and the SM (at NNLO+)
+class dr_SMEFTLO : public dr_SMNNLO {
+  public:
+  using dr_SMNNLO::dr_SMNNLO;
+  double resSMEFT(void) const;
+  Cplx result(void) const{
+    return(dr_SMNNLO::result()+resSMEFT());
+  }
+};
+
+/* input class that computes MW from Gmu */
+class invalGmuSMEFT : public invalGmu {
+  protected:
+    vector<vector<vector<vector<vector<double>>>>> dataSMEFTG;
+    void compute(void);
+  public:
+    using invalGmu::invalGmu;
+    using invalGmu::set;
+    using invalGmu::get;
+    invalGmuSMEFT(const int sizealloc) : dataSMEFTG(sizealloc, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
+    invalGmuSMEFT(void) : invalGmuSMEFT(SIZE1) {};
+    invalGmuSMEFT(const inval& copyfrom) : invalGmu(copyfrom), dataSMEFTG(SIZE1, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
+
+    //set Wilson coefficient values
+    void set(const int idx, const double val) override
+    {
+      if(idx < data.size() & idx > 29)
+        dataSMEFTG[idx][0][0][0][0] = val;
+      else if(idx < data.size()){
+        data[idx] = val;
+      } else
+      {
+        cerr << "Input value index " << idx << " outside of range" << endl;
+        exit(1);
+      }
+      compute();
+    }
+
+    void set(const int idx, const double val, const int gen1, const int gen2)
+    {
+      if(idx < data.size() & idx > 29)
+        dataSMEFTG[idx][gen1-1][gen2-1][0][0] = val;
+      else if(idx < data.size()){
+        data[idx] = val;
+      } else
+      {
+        cerr << "Input value index " << idx << " outside of range" << endl;
+        exit(1);
+      }
+        compute();
+    }
+    
+    void set(const int idx, const double val, const int gen1, const int gen2, const int gen3, const int gen4)
+    {
+      if(idx < data.size() & idx > 29)
+      {
+        dataSMEFTG[idx][gen1-1][gen2-1][gen3-1][gen4-1] = val;
+      }
+      else if(idx < data.size())
+      {
+        data[idx] = val;
+      } else
+      {
+        cerr << "Input value index " << idx << " outside of range" << endl;
+        exit(1);
+      }
+      compute();
+    }
+
+    //get Wilson coefficient values
+    double get(const int idx) const override
+    {
+      if(idx < data.size() & idx > 29)
+      {
+        if(isfinite(dataSMEFTG[idx][0][0][0][0]))
+          return(dataSMEFTG[idx][0][0][0][0]);
+      } else
+      {
+        if(isfinite(data[idx]))
+          return(data[idx]); 
+      }
+      cerr << "Invalid or undefined input value for index " << idx << endl;
+      exit(1);
+    }
+
+    double get(const int idx, const int gen1, const int gen2) const override
+    {
+      if(idx < data.size() & idx > 29)
+      {
+        if(isfinite(dataSMEFTG[idx][gen1-1][gen2-1][0][0]))
+          return(dataSMEFTG[idx][gen1-1][gen2-1][0][0]);
+      } else
+      {
+        if(isfinite(data[idx]))
+          return(data[idx]); 
+      }
+      cerr << "Invalid or undefined input value for index " << idx << endl;
+      exit(1);
+    }
+    
+    double get(const int idx, const int gen1, const int gen2, const int gen3, const int gen4) const override
+    {
+      if(idx < data.size() & idx > 29)
+      {
+        if(isfinite(dataSMEFTG[idx][gen1-1][gen2-1][gen3-1][gen4-1]))
+          return(dataSMEFTG[idx][gen1-1][gen2-1][gen3-1][gen4-1]);
+      } else
+      {
+        if(isfinite(data[idx]))
+          return(data[idx]); 
+      }
+      cerr << "Invalid or undefined input value for index " << idx << endl;
+      exit(1);
+    }
+};
+
+} // namespace
+
+#endif // __deltarSMEFT__

--- a/deltarSMEFT.h
+++ b/deltarSMEFT.h
@@ -34,9 +34,6 @@ class dr_SMEFTLO : public dr_SMNNLO {
   public:
   using dr_SMNNLO::dr_SMNNLO;
   double resSMEFT(void) const;
-  Cplx result(void) const{
-    return(dr_SMNNLO::result()+resSMEFT());
-  }
 };
 
 /* input class that computes MW from Gmu */
@@ -52,7 +49,7 @@ class invalGmuSMEFT : public invalGmu {
     invalGmuSMEFT(void) : invalGmuSMEFT(SIZE1) {};
     invalGmuSMEFT(const inval& copyfrom) : invalGmu(copyfrom), dataSMEFTG(SIZE1, vector<vector<vector<vector<double>>>>(3,vector<vector<vector<double>>>(3,vector<vector<double>>(3,vector<double>(3,NAN))))) {};
 
-    //set Wilson coefficient values
+    // set Wilson coefficient values
     void set(const int idx, const double val) override
     {
       if(idx < data.size() & idx > 29)
@@ -98,7 +95,7 @@ class invalGmuSMEFT : public invalGmu {
       compute();
     }
 
-    //get Wilson coefficient values
+    // get Wilson coefficient values
     double get(const int idx) const override
     {
       if(idx < data.size() & idx > 29)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,3 +26,9 @@ target_link_libraries(testdeltar PUBLIC griffin)
 
 add_executable(testtools testtools.cc)
 target_link_libraries(testtools PUBLIC griffin)
+
+add_executable(testSW testSW.cc)
+target_link_libraries(testSW PUBLIC griffin)
+
+add_executable(test4f test4f.cc)
+target_link_libraries(test4f PUBLIC griffin)

--- a/examples/test4f.cc
+++ b/examples/test4f.cc
@@ -1,0 +1,109 @@
+#include <iostream>
+using namespace std;
+
+#include "EWPOZSMEFT.h"
+#include "xscnnlo.h"
+#include "xscSMEFT.h"
+#include "SMEFTval.h"
+using namespace griffin;
+
+int main()
+{
+  cout<<"======================================================"<<endl;
+  cout<<"======================================================"<<endl;
+
+  cout<<"     ______ ____   ____ ______ ______ ____ _   __"<<endl;
+  cout<<"    / ____// __ \\ /  _// ____// ____//  _// | / /"<<endl;
+  cout<<"   / / __ / /_/ / / / / /_   / /_    / / /  |/ / "<<endl;
+  cout<<"  / /_/ // _, _/_/ / / __/  / __/  _/ / / /|  /  "<<endl;
+  cout<<"  \\____//_/ |_|/___//_/    /_/    /___//_/ |_/   "<<endl;
+
+  cout<<"======================================================"<<endl;
+  cout<<"======================================================"<<endl;
+
+  SMval myinput1;   // convert masses from PDG values to complex pole scheme
+  myinput1.set(al, 1/137.03599976);
+  myinput1.set(MZ, 91.1876);
+  myinput1.set(MW, 80.377);
+  myinput1.set(GamZ, 2.4952);
+  myinput1.set(GamW, 2.085);
+  myinput1.set(MH, 125.1);
+  myinput1.set(MT, 172.5);
+  myinput1.set(MB, 2.87);
+  myinput1.set(Delal, 0.059);
+  myinput1.set(als, 0.1179);   
+
+  SMEFTval myinput2;        
+  myinput2.set(al, 1/137.03599976);
+  myinput2.set(MZ, 91.1876);
+  myinput2.set(MW, 80.377);
+  myinput2.set(GamZ, 2.4952);
+  myinput2.set(GamW, 2.085);
+  myinput2.set(MH, 125.1);
+  myinput2.set(MT, 172.5);
+  myinput2.set(MB, 2.87);
+  myinput2.set(Delal, 0.059);
+  myinput2.set(als, 0.1179);
+  myinput2.set(Clq3,0.060516,3,3,3,3);
+  myinput2.set(Clq1,0.060516,3,3,3,3);
+  myinput2.set(Cld,0.060516/4,3,3,3,3);
+
+
+  cout << endl << "Complex-pole masses: MW=" << myinput1.get(MWc) << ", MZ=" 
+    << myinput1.get(MZc) << endl << endl;
+  cout << endl << "Complex-pole masses: MW=" << myinput2.get(MWc) << ", MZ=" 
+    << myinput2.get(MZc) << endl << endl;
+ 
+  // compute matrix element for ee->ee with vector coupling in initial
+  // state and vector coupling in final state
+  int ini = BQU, fin = DQU, iff = VEC, off = VEC;
+  
+  cout << "=== Matrix element for ee->ee (i=e, f=ee) ===" << endl << endl;
+  
+  // compute vertex form factors:
+  FA_SMNNLO FAi(ini, myinput1), FAf(fin, myinput1);
+  SW_SMNNLO SWi(ini, myinput1), SWf(fin, myinput1);
+  FA_SMEFTLO FAi2(ini, myinput2), FAf2(fin, myinput2);
+  SW_SMEFTLO SWi2(ini, myinput2), SWf2(fin, myinput2);
+  cout << "F_A^i (NNLO+) = " << FAi.result() << endl;
+  cout << "F_A^i (SMEFTLO+) = " << FAi2.result() << endl;
+  cout << "F_A^f (NNLO+) = " << FAf.result() << endl;
+  cout << "F_A^f (SMEFTLO+) = " << FAf2.result() << endl;
+  cout << "sineff^i (NNLO+) = " << SWi.result() << endl;
+  cout << "sineff^i (SMEFTLO+) = " << SWi2.result() << endl;
+  cout << "sineff^f (NNLO+) = " << SWf.result() << endl;
+  cout << "sineff^f (SMEFTLO+) = " << SWf2.result() << endl;
+  cout << endl;
+  
+  double cme,        // center-of-mass energy
+         cost = 0.5; // scattering angle
+  Cplx res1, res2;
+
+  cout << "SM matrix element M_VV for cos(theta)=" << cost << ": " << endl;
+  // compute matrix element for ee->ee using SM form factors:
+  mat_SMNNLO M1(ini, fin, iff, off, FAi, FAf, SWi, SWf, cme*cme, cost, myinput1);
+  cout << "sqrt(s)\t\ttot. result\t\toff-resonance contrib." << endl;
+  for(cme = 10.; cme <= 190.; cme += 20.)
+  {
+    M1.setkinvar(cme*cme, cost);
+    res1 = M1.result();
+    res2 = M1.resoffZ();
+    cout << cme << " \t" << res1 << " \t" << res2 << endl;
+  }
+  cout << endl;
+
+  cout << "SMEFT matrix element M_VV for cos(theta)=" << cost << ": " << endl;
+  // compute matrix element for ee->ee using SM form factors:
+  mat_SMEFTLO M2(ini, fin, iff, off, FAi2, FAf2, SWi2, SWf2, cme*cme, cost, myinput2);
+  cout << "sqrt(s)\t\ttot. result\t\toff-resonance contrib." << endl;
+  for(cme = 10.; cme <= 190.; cme += 20.)
+  {
+    M2.setkinvar(cme*cme, cost);
+    res1 = M2.result();
+    res2 = M2.resoffZ();
+    cout << cme << " \t" << res1 << " \t" << res2 << endl;
+  }
+  cout << endl;
+
+  return 0;
+}

--- a/examples/test4f.cc
+++ b/examples/test4f.cc
@@ -44,9 +44,24 @@ int main()
   myinput2.set(MB, 2.87);
   myinput2.set(Delal, 0.059);
   myinput2.set(als, 0.1179);
-  myinput2.set(Clq3,0.060516,3,3,3,3);
-  myinput2.set(Clq1,0.060516,3,3,3,3);
-  myinput2.set(Cld,0.060516/4,3,3,3,3);
+  myinput2.set(Cll,0.060516,1,1,2,2);
+  myinput2.set(Cll,0.060516,1,2,2,1);
+  myinput2.set(Cll,0.060516,2,2,1,1);
+  myinput2.set(Cll,0.060516,2,1,1,2);
+  myinput2.set(Cee,0.060516/3.,1,1,2,2);
+  myinput2.set(Cee,0.060516/3.,1,2,2,1);
+  myinput2.set(Cee,0.060516/3.,2,2,1,1);
+  myinput2.set(Cee,0.060516/3.,2,1,1,2);
+  myinput2.set(Cle,0.060516/2.,1,1,2,2);
+  myinput2.set(Cle,0.060516/4.,2,2,1,1);
+  myinput2.set(CphiD,0);
+  myinput2.set(CphiWB,0);
+  myinput2.set(Cphie,0,1,1);
+  myinput2.set(Cphil1,0,1,1);
+  myinput2.set(Cphil3,0,1,1);
+  myinput2.set(Cphie,0,2,2);
+  myinput2.set(Cphil1,0,2,2);
+  myinput2.set(Cphil3,0,2,2);
 
 
   cout << endl << "Complex-pole masses: MW=" << myinput1.get(MWc) << ", MZ=" 
@@ -54,9 +69,9 @@ int main()
   cout << endl << "Complex-pole masses: MW=" << myinput2.get(MWc) << ", MZ=" 
     << myinput2.get(MZc) << endl << endl;
  
-  // compute matrix element for ee->ee with vector coupling in initial
+  // compute matrix element for ee->mumu with vector coupling in initial
   // state and vector coupling in final state
-  int ini = BQU, fin = DQU, iff = VEC, off = VEC;
+  int ini = ELE, fin = MUO, iff = VEC, off = VEC;
   
   cout << "=== Matrix element for ee->ee (i=e, f=ee) ===" << endl << endl;
   
@@ -80,7 +95,7 @@ int main()
   Cplx res1, res2;
 
   cout << "SM matrix element M_VV for cos(theta)=" << cost << ": " << endl;
-  // compute matrix element for ee->ee using SM form factors:
+  // compute matrix element for ee->mumu using SM form factors:
   mat_SMNNLO M1(ini, fin, iff, off, FAi, FAf, SWi, SWf, cme*cme, cost, myinput1);
   cout << "sqrt(s)\t\ttot. result\t\toff-resonance contrib." << endl;
   for(cme = 10.; cme <= 190.; cme += 20.)
@@ -93,7 +108,7 @@ int main()
   cout << endl;
 
   cout << "SMEFT matrix element M_VV for cos(theta)=" << cost << ": " << endl;
-  // compute matrix element for ee->ee using SM form factors:
+  // compute matrix element for ee->mumu using SMEFT form factors:
   mat_SMEFTLO M2(ini, fin, iff, off, FAi2, FAf2, SWi2, SWf2, cme*cme, cost, myinput2);
   cout << "sqrt(s)\t\ttot. result\t\toff-resonance contrib." << endl;
   for(cme = 10.; cme <= 190.; cme += 20.)

--- a/examples/testSW.cc
+++ b/examples/testSW.cc
@@ -51,8 +51,8 @@ int main()
   myinput2.set(Cphie,0.060516,1,1);
 
 
-  // compute matrix element for ee->dd with vector coupling in initial
-  // state and vector coupling in final state
+  // compute effective weak mixing angle and vertex form factors for ee with vector coupling in initial
+  // state
   int ini = ELE;
   
   // compute vertex form factors:

--- a/examples/testSW.cc
+++ b/examples/testSW.cc
@@ -1,0 +1,84 @@
+#include <iostream>
+using namespace std;
+
+#include "EWPOZSMEFT.h"
+#include "xscaas.h"
+#include "SMEFTval.h"
+using namespace griffin;
+
+int main()
+{
+  cout<<"======================================================"<<endl;
+  cout<<"======================================================"<<endl;
+
+  cout<<"     ______ ____   ____ ______ ______ ____ _   __"<<endl;
+  cout<<"    / ____// __ \\ /  _// ____// ____//  _// | / /"<<endl;
+  cout<<"   / / __ / /_/ / / / / /_   / /_    / / /  |/ / "<<endl;
+  cout<<"  / /_/ // _, _/_/ / / __/  / __/  _/ / / /|  /  "<<endl;
+  cout<<"  \\____//_/ |_|/___//_/    /_/    /___//_/ |_/   "<<endl;
+
+  cout<<"======================================================"<<endl;
+  cout<<"======================================================"<<endl;
+
+  SMval myinput1;   // convert masses from PDG values to complex pole scheme
+  myinput1.set(al, 1/137.03599976);
+  myinput1.set(MZ, 91.1876);
+  myinput1.set(MW, 80.377);
+  myinput1.set(GamZ, 2.4952);
+  myinput1.set(GamW, 2.085);
+  myinput1.set(MH, 125.1);
+  myinput1.set(MT, 172.5);
+  myinput1.set(MB, 2.87);
+  myinput1.set(Delal, 0.059);
+  myinput1.set(als, 0.1179);   
+
+  SMEFTval myinput2;        
+  myinput2.set(al, 1/137.03599976);
+  myinput2.set(MZ, 91.1876);
+  myinput2.set(MW, 80.377);
+  myinput2.set(GamZ, 2.4952);
+  myinput2.set(GamW, 2.085);
+  myinput2.set(MH, 125.1);
+  myinput2.set(MT, 172.5);
+  myinput2.set(MB, 2.87);
+  myinput2.set(Delal, 0.059);
+  myinput2.set(als, 0.1179);
+  myinput2.set(CphiD,0.060516);
+  myinput2.set(CphiWB,0.060516);
+  myinput2.set(Cphil1,0.060516,1,1);
+  myinput2.set(Cphil3,0.060516,1,1);
+  myinput2.set(Cphiq3,0.060516,1,1);
+  myinput2.set(Cphie,0.060516,1,1);
+
+
+  // compute matrix element for ee->dd with vector coupling in initial
+  // state and vector coupling in final state
+  int ini = ELE;
+  
+  // compute vertex form factors:
+  SW_SMNNLO SW1(ini, myinput1);
+  SW_SMEFTLO SW2(ini, myinput2);
+
+  FA_SMNNLO FA1(ini, myinput1);
+  FA_SMEFTLO FA2(ini, myinput2);
+
+  FV_SMNNLO FV1(ini, myinput1);
+  FV_SMEFTLO FV2(ini, myinput2);
+
+  cout << myinput1.get(MWc) << endl;
+  cout << myinput1.get(MZc) << endl;
+
+  cout << myinput2.get(MWc) << endl;
+  cout << myinput2.get(MZc) << endl;
+
+  cout << "NNLO SM SW for initial e+e-: " << SW1.result() << endl;
+  cout << "SMEFT SW for initial e+e-: " << SW2.result() << endl;
+
+  cout << "NNLO SM FA for initial e+e-: " << FA1.result() << endl;
+  cout << "SMEFT FA for initial e+e-: " << FA2.result() << endl;
+
+  cout << "NNLO SM FV for initial e+e-: " << FV1.result() << endl;
+  cout << "SMEFT FV for initial e+e-: " << FV2.result() << endl;
+
+  return 0;
+}

--- a/examples/testdeltar.cc
+++ b/examples/testdeltar.cc
@@ -53,12 +53,12 @@ int main()
   cout << endl;
 
   SMEFTvalGmu myinput3(myinput);
-  myinput3.set(Cll,0.060516*0.021,1,2,2,1);
-  myinput3.set(Cll,0.060516*0.021,2,1,1,2);
-  myinput3.set(Cphil3,0.060516*0.012,1,1);
-  myinput3.set(Cphil3,0.060516*0.012,2,2);
-  myinput3.set(CphiD,0.060516*0.025);
-  myinput3.set(CphiWB,0.060516*0.0088);
+  myinput3.set(Cll,0.06693378,1,2,2,1);
+  myinput3.set(Cll,0.06693378,2,1,1,2);
+  myinput3.set(Cphil3,0.06693378/2,1,1);
+  myinput3.set(Cphil3,0.06693378/2,2,2);
+  myinput3.set(CphiD,0.06693378/3);
+  myinput3.set(CphiWB,0.06693378/4);
   cout << endl;
   cout << "complex-pole mass: mw = " << myinput3.get(MWc) << endl;
   cout << "PDG mass:          mw = " << myinput3.get(MW) << endl;

--- a/examples/testdeltar.cc
+++ b/examples/testdeltar.cc
@@ -2,7 +2,7 @@
 using namespace std;
 
 #include "deltar.h"
-#include "SMvalG.h"
+#include "SMEFTvalG.h"
 using namespace griffin;
 
 int main()
@@ -50,6 +50,18 @@ int main()
   cout << endl;
   cout << "complex-pole mass: mw = " << myinput2.get(MWc) << endl;
   cout << "PDG mass:          mw = " << myinput2.get(MW) << endl;
+  cout << endl;
+
+  SMEFTvalGmu myinput3(myinput);
+  myinput3.set(Cll,0.060516*0.021,1,2,2,1);
+  myinput3.set(Cll,0.060516*0.021,2,1,1,2);
+  myinput3.set(Cphil3,0.060516*0.012,1,1);
+  myinput3.set(Cphil3,0.060516*0.012,2,2);
+  myinput3.set(CphiD,0.060516*0.025);
+  myinput3.set(CphiWB,0.060516*0.0088);
+  cout << endl;
+  cout << "complex-pole mass: mw = " << myinput3.get(MWc) << endl;
+  cout << "PDG mass:          mw = " << myinput3.get(MW) << endl;
   cout << endl;
 
   return 0;

--- a/ff.cc
+++ b/ff.cc
@@ -1,7 +1,7 @@
 /*-----------------------------------------------------------------------------
 ff.cc 
 Lisong Chen (lic114@pitt.edu), Ayres Freitas (afreitas@pitt.edu)
-last revision: 15 Aug 2024
+last revision: 11 Jun 2026
 -------------------------------------------------------------------------------
 one-loop self-energy, vertex and box form factors
 -----------------------------------------------------------------------------*/
@@ -24,6 +24,8 @@ extern const double I3f[20];
 #include "box1.in"
 #include "boxs1.in"
 #include "box1s0.in"
+
+// import SMEFT corrections
 #include "ffSMEFT0.in"
 
 } // namespace

--- a/ff.cc
+++ b/ff.cc
@@ -24,5 +24,6 @@ extern const double I3f[20];
 #include "box1.in"
 #include "boxs1.in"
 #include "box1s0.in"
+#include "ffSMEFT0.in"
 
 } // namespace

--- a/ff.h
+++ b/ff.h
@@ -1,6 +1,7 @@
 /* ff.h: header file for ff.cc */
 
 #include "classes.h"
+#include "SMEFTval.h"
 
 namespace griffin {
 
@@ -68,6 +69,12 @@ double ig1f(int type, int form, const inval& input);
 double rg1b(int type, int form, const inval& input);
 // imag. part of bosonic one-loop photon vertex factor for k^2=mz^2
 double ig1b(int type, int form, const inval& input);
+
+// SMEFT tree-level Z vertex factor for k^2=mz^2
+double z0SMEFT(int type, int form, const inval& input);
+
+// SMEFT tree-level matrix element
+double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input);
 
 // one-loop box diagrams for s=mz^2
 // it/ot: ini-state/fin-state fermion type

--- a/ff.h
+++ b/ff.h
@@ -70,7 +70,7 @@ double rg1b(int type, int form, const inval& input);
 // imag. part of bosonic one-loop photon vertex factor for k^2=mz^2
 double ig1b(int type, int form, const inval& input);
 
-// SMEFT tree-level Z vertex factor for k^2=mz^2
+// SMEFT tree-level Z vertex factor
 double z0SMEFT(int type, int form, const inval& input);
 
 // SMEFT tree-level matrix element

--- a/ffSMEFT0.in
+++ b/ffSMEFT0.in
@@ -13,9 +13,12 @@ double z0SMEFT(int type, int form, const inval& input)
          Lambdas = sqr(246),
          deltagRZf = 0,
          deltagLZf = 0;
+  double el = sqrt(4*Pi*AL),
+         cw = sqrt(MWs/MZs);
+  double sw = sqrt(1-cw*cw);
   switch(type) {
     case ELE:
-      CPHIF  = input.get(Cphie,1,1); // entries refer to generation indices in the Wilson coeff
+      CPHIF  = input.get(Cphie,1,1); // get arguments refer to generation indices of the Wilson coeff
       CPHIF1 = input.get(Cphil1,1,1);
       CPHIF3 = input.get(Cphil3,1,1);
       break;
@@ -69,18 +72,19 @@ double z0SMEFT(int type, int form, const inval& input)
       CPHIF1 = input.get(Cphiq1,3,3);
       CPHIF3 = input.get(Cphiq3,3,3);
       break;
-  }
+  } 
+  // results derived from 1704.03888
   deltagLZf = CPhiD/Lambdas*MWs/(8*Pi*AL)*(2*(I3f[type]-Qf[type])-2*(2*I3f[type]-Qf[type])*MWs/MZs)+CPHIF1/Lambdas*(1-MWs/MZs)*MWs/(2*Pi*AL)-I3f[type]*CPHIF3/Lambdas*(1-MWs/MZs)*MWs/(Pi*AL)-I3f[type]*CPhiWB/Lambdas*MWs*sqrt(MWs)/(Pi*AL)/MZs*sqrt(MZs-MWs);
   deltagRZf = CPHIF/Lambdas*(1-MWs/MZs)*MWs/(2*Pi*AL)-Qf[type]*CPhiD/Lambdas*(1-MWs/MZs)*MWs/(4*Pi*AL);
   switch(form) {
    case VEC:
-    res = deltagLZf+deltagRZf;
+    res = el/(2*sw*cw)*(deltagLZf+deltagRZf);
     break;
    case AXV:
-    res = deltagLZf-deltagRZf;
+    res = el/(2*sw*cw)*(deltagLZf-deltagRZf);
     break;
   }
-  return(res);
+  return(-res); // minus sign to align with sign convention of vz0 and az0
 }
 
 double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
@@ -99,12 +103,15 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
          Cle0 = 0,
          Cle1 = 0,
          Clu0 = 0,
+         Clu1 = 0,
          Cld0 = 0,
+         Cld1 = 0,
          Cqe0 = 0,
-         LL = 0,
-         RR = 0,
-         LR = 0,
-         RL = 0,
+         Cqe1 = 0,
+         LLLL = 0,
+         RRRR = 0,
+         LLRR = 0,
+         RRLL = 0,
          Lambdas = sqr(246),
          res = 0;
   int ftypeToGen[17] = {0,1,1,2,2,3,3,0,0,0,0,1,1,2,2,3,3};
@@ -123,6 +130,7 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
     Cee3 = input.get(Cee,ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot]); 
     Cle0 = input.get(Cle,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); 
     Cle1 = input.get(Cle,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+
   } else if ( (it==ELE || it==MUO || it==TAU) && (ot==NUE || ot==NUM || ot==NUT) )
   {
     Cll0 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
@@ -132,7 +140,7 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
   {
     Cll0 = input.get(Cll,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Cll1 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
-    Cle1 = input.get(Cle,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cle0 = input.get(Cle,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
   } else if ( (it==NUE || it==NUM || it==NUT) && (ot == NUE|| ot==NUM || ot==NUT) )
   {
     if(it==ot){
@@ -149,13 +157,13 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
     Clq30 = -input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); // Clq3 sign based on isospin of both particles?
     Ceu0 = input.get(Ceu,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
     Clu0 = input.get(Clu,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
-    Cqe0 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cqe1 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
   } else if( (it==UQU || it==CQU) && (ot==ELE || ot==MUO || ot==TAU) )
   {
     Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Clq30 = -input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Ceu0 = input.get(Ceu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
-    Clu0 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clu1 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Cqe0 = input.get(Cqe,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
   } else if( (it==ELE || it==MUO || it==TAU) && (ot==DQU || ot==SQU || ot==BQU) )
   {
@@ -163,13 +171,13 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
     Clq30 = input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
     Ced0 = input.get(Ced,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
     Cld0 = input.get(Cld,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
-    Cqe0 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cqe1 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
   } else if( (it==DQU || it==SQU || it==BQU) && (ot==ELE || ot==MUO || ot==TAU) )
   {
     Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Clq30 = input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Ced0 = input.get(Ced,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
-    Cld0 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cld1 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Cqe0 = input.get(Cqe,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
   } else if( (it==NUE || it==NUM || it==NUT) && (ot==UQU || ot==CQU) )
   {
@@ -180,7 +188,7 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
   {
     Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Clq30 = input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
-    Clu0 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clu1 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
   } else if( (it==NUE || it==NUM || it==NUT) && (ot==DQU || ot==SQU || ot==BQU) )
   {
     Clq10 = input.get(Clq1,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
@@ -190,24 +198,24 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
   {
     Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
     Clq30 = -input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
-    Cld0 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cld1 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
   } else{
     cout << "This combination of fermions has not been implemented in GRIFFIN for the SMEFT!" << endl;
   }
-  LL = -1/Lambdas*(Cll0+Cll1+Cll2+Cll3+Clq10+Clq30);
-  RR = -1/Lambdas*(Cee0+Cee1+Cee2+Cee3+Ceu0+Ced0);
-  RL = -1/Lambdas*(Cle0+Clu0+Cld0);
-  LR = -1/Lambdas*(Cle1+Cqe0);
+  LLLL = -1/Lambdas*(Cll0+Cll1+Cll2+Cll3+Clq10+Clq30); // SMEFT contributions to four fermion interactions derived from 1704.03888 
+  RRRR = -1/Lambdas*(Cee0+Cee1+Cee2+Cee3+Ceu0+Ced0);
+  LLRR = -1/Lambdas*(Cle0+Cqe0+Clu0+Cld0);
+  RRLL = -1/Lambdas*(Cle1+Cqe1+Clu1+Cld1);
   switch(if1)
   {
     case VEC:
      switch(of1)
      {
       case VEC:
-        res = 0.25*(LL+RR+LR+RL);
+        res = 0.25*(LLLL+RRRR+LLRR+RRLL);
         break;
       case AXV:
-        res = 0.25*(-LL+RR+LR-RL);
+        res = 0.25*(-LLLL+RRRR+LLRR-RRLL);
         break;
      }
      break;
@@ -215,12 +223,21 @@ double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
       switch(of1)
       {
         case VEC:
-          res = 0.25*(-LL+RR-LR+RL);
+          res = 0.25*(-LLLL+RRRR-LLRR+RRLL);
           break;
         case AXV:
-          res = 0.25*(LL+RR-LR-RL);
+          res = 0.25*(LLLL+RRRR-LLRR-RRLL);
           break;
       }
+      break;
+    case SCA:
+      cout << "This option has not been implemented for the SMEFT yet!" << endl;
+      res = 0;
+      break;
+    case PSC:
+      cout << "This option has not been implemented for the SMEFT yet!" << endl;
+      res = 0;
+      break;
   }
   return(res);
 }

--- a/ffSMEFT0.in
+++ b/ffSMEFT0.in
@@ -1,0 +1,226 @@
+// SMEFT Z vertex factor
+double z0SMEFT(int type, int form, const inval& input)
+{
+  double MZs = sqr(input.get(MZ)),
+         MWs = sqr(input.get(MW)),
+         AL = input.get(al),
+         CPHIF = 0,
+         CPHIF1 = 0,
+         CPHIF3 = 0,
+         CPhiD = input.get(CphiD),
+         CPhiWB = input.get(CphiWB),
+         res = 0,
+         Lambdas = sqr(246),
+         deltagRZf = 0,
+         deltagLZf = 0;
+  switch(type) {
+    case ELE:
+      CPHIF  = input.get(Cphie,1,1); // entries refer to generation indices in the Wilson coeff
+      CPHIF1 = input.get(Cphil1,1,1);
+      CPHIF3 = input.get(Cphil3,1,1);
+      break;
+    case MUO:
+      CPHIF  = input.get(Cphie,2,2);
+      CPHIF1 = input.get(Cphil1,2,2);
+      CPHIF3 = input.get(Cphil3,2,2);
+      break;
+    case TAU:
+      CPHIF  = input.get(Cphie,3,3);
+      CPHIF1 = input.get(Cphil1,3,3);
+      CPHIF3 = input.get(Cphil3,3,3);
+      break;
+    case NUE:
+      CPHIF  = 0;
+      CPHIF1 = input.get(Cphil1,1,1);
+      CPHIF3 = input.get(Cphil3,1,1);
+      break;
+    case NUM:
+      CPHIF  = 0;
+      CPHIF1 = input.get(Cphil1,2,2);
+      CPHIF3 = input.get(Cphil3,2,2);
+      break;
+    case NUT:
+      CPHIF = 0;
+      CPHIF1 = input.get(Cphil1,3,3);
+      CPHIF3 = input.get(Cphil3,3,3);
+      break;
+    case DQU:
+      CPHIF  = input.get(Cphid,1,1);
+      CPHIF1 = input.get(Cphiq1,1,1);
+      CPHIF3 = input.get(Cphiq3,1,1);
+      break;
+    case UQU:
+      CPHIF  = input.get(Cphiu,1,1);
+      CPHIF1 = input.get(Cphiq1,1,1);
+      CPHIF3 = input.get(Cphiq3,1,1);
+      break;
+    case SQU:
+      CPHIF  = input.get(Cphid,2,2);
+      CPHIF1 = input.get(Cphiq1,2,2);
+      CPHIF3 = input.get(Cphiq3,2,2);
+      break;
+    case CQU:
+      CPHIF  = input.get(Cphiu,2,2);
+      CPHIF1 = input.get(Cphiq1,2,2);
+      CPHIF3 = input.get(Cphiq3,2,2);
+      break;
+    case BQU:
+      CPHIF  = input.get(Cphid,3,3);
+      CPHIF1 = input.get(Cphiq1,3,3);
+      CPHIF3 = input.get(Cphiq3,3,3);
+      break;
+  }
+  deltagLZf = CPhiD/Lambdas*MWs/(8*Pi*AL)*(2*(I3f[type]-Qf[type])-2*(2*I3f[type]-Qf[type])*MWs/MZs)+CPHIF1/Lambdas*(1-MWs/MZs)*MWs/(2*Pi*AL)-I3f[type]*CPHIF3/Lambdas*(1-MWs/MZs)*MWs/(Pi*AL)-I3f[type]*CPhiWB/Lambdas*MWs*sqrt(MWs)/(Pi*AL)/MZs*sqrt(MZs-MWs);
+  deltagRZf = CPHIF/Lambdas*(1-MWs/MZs)*MWs/(2*Pi*AL)-Qf[type]*CPhiD/Lambdas*(1-MWs/MZs)*MWs/(4*Pi*AL);
+  switch(form) {
+   case VEC:
+    res = deltagLZf+deltagRZf;
+    break;
+   case AXV:
+    res = deltagLZf-deltagRZf;
+    break;
+  }
+  return(res);
+}
+
+double r4fSMEFT(int it, int ot, int if1, int of1, const inval& input){
+  double Cll0 = 0,
+         Cll1 = 0,
+         Cll2 = 0,
+         Cll3 = 0,
+         Clq10 = 0,
+         Clq30 = 0,
+         Cee0 = 0,
+         Cee1 = 0,
+         Cee2 = 0,
+         Cee3 = 0,
+         Ceu0 = 0,
+         Ced0 = 0,
+         Cle0 = 0,
+         Cle1 = 0,
+         Clu0 = 0,
+         Cld0 = 0,
+         Cqe0 = 0,
+         LL = 0,
+         RR = 0,
+         LR = 0,
+         RL = 0,
+         Lambdas = sqr(246),
+         res = 0;
+  int ftypeToGen[17] = {0,1,1,2,2,3,3,0,0,0,0,1,1,2,2,3,3};
+  if ( (it==ELE || it==MUO || it==TAU) && (ot==ELE || ot==MUO || ot==TAU) )
+  {
+    if(it==ot){
+      cout << "Warning: same-type fermions are not fully implemented for SMEFT yet" << endl;
+    }
+    Cll0 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); 
+    Cll1 = input.get(Cll,ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it]); 
+    Cll2 = input.get(Cll,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]); 
+    Cll3 = input.get(Cll,ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot]);
+    Cee0 = input.get(Cee,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); 
+    Cee1 = input.get(Cee,ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it]); 
+    Cee2 = input.get(Cee,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]); 
+    Cee3 = input.get(Cee,ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot]); 
+    Cle0 = input.get(Cle,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); 
+    Cle1 = input.get(Cle,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else if ( (it==ELE || it==MUO || it==TAU) && (ot==NUE || ot==NUM || ot==NUT) )
+  {
+    Cll0 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cll1 = input.get(Cll,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cle1 = input.get(Cle,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else if ( (it==NUE || it==NUM || it==NUT) && (ot==ELE || ot==MUO || ot==TAU))
+  {
+    Cll0 = input.get(Cll,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cll1 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cle1 = input.get(Cle,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+  } else if ( (it==NUE || it==NUM || it==NUT) && (ot == NUE|| ot==NUM || ot==NUT) )
+  {
+    if(it==ot){
+      cout << "Warning: same-type fermions are not fully implemented for SMEFT yet" << endl;
+    }
+    Cll0 = input.get(Cll,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cll1 = input.get(Cll,ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it]);
+    Cll2 = input.get(Cll,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cll3 = input.get(Cll,ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot]);
+
+  } else if( (it==ELE || it==MUO || it==TAU) && (ot==UQU || ot==CQU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clq30 = -input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]); // Clq3 sign based on isospin of both particles?
+    Ceu0 = input.get(Ceu,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clu0 = input.get(Clu,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cqe0 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else if( (it==UQU || it==CQU) && (ot==ELE || ot==MUO || ot==TAU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clq30 = -input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Ceu0 = input.get(Ceu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clu0 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cqe0 = input.get(Cqe,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+  } else if( (it==ELE || it==MUO || it==TAU) && (ot==DQU || ot==SQU || ot==BQU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clq30 = input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Ced0 = input.get(Ced,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cld0 = input.get(Cld,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cqe0 = input.get(Cqe,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else if( (it==DQU || it==SQU || it==BQU) && (ot==ELE || ot==MUO || ot==TAU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clq30 = input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Ced0 = input.get(Ced,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cld0 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cqe0 = input.get(Cqe,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+  } else if( (it==NUE || it==NUM || it==NUT) && (ot==UQU || ot==CQU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clq30 = input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clu0 = input.get(Clu,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+  } else if( (it==UQU || it==CQU) & (ot==NUE || ot==NUM || ot==NUT) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clq30 = input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clu0 = input.get(Clu,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else if( (it==NUE || it==NUM || it==NUT) && (ot==DQU || ot==SQU || ot==BQU) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Clq30 = -input.get(Clq3,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+    Cld0 = input.get(Cld,ftypeToGen[it],ftypeToGen[it],ftypeToGen[ot],ftypeToGen[ot]);
+  } else if( (it==DQU || it==SQU || it==BQU) & (ot==NUE || ot==NUM || ot==NUT) )
+  {
+    Clq10 = input.get(Clq1,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Clq30 = -input.get(Clq3,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+    Cld0 = input.get(Cld,ftypeToGen[ot],ftypeToGen[ot],ftypeToGen[it],ftypeToGen[it]);
+  } else{
+    cout << "This combination of fermions has not been implemented in GRIFFIN for the SMEFT!" << endl;
+  }
+  LL = -1/Lambdas*(Cll0+Cll1+Cll2+Cll3+Clq10+Clq30);
+  RR = -1/Lambdas*(Cee0+Cee1+Cee2+Cee3+Ceu0+Ced0);
+  RL = -1/Lambdas*(Cle0+Clu0+Cld0);
+  LR = -1/Lambdas*(Cle1+Cqe0);
+  switch(if1)
+  {
+    case VEC:
+     switch(of1)
+     {
+      case VEC:
+        res = 0.25*(LL+RR+LR+RL);
+        break;
+      case AXV:
+        res = 0.25*(-LL+RR+LR-RL);
+        break;
+     }
+     break;
+    case AXV:
+      switch(of1)
+      {
+        case VEC:
+          res = 0.25*(-LL+RR-LR+RL);
+          break;
+        case AXV:
+          res = 0.25*(LL+RR-LR-RL);
+          break;
+      }
+  }
+  return(res);
+}

--- a/xscSMEFT.cc
+++ b/xscSMEFT.cc
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------
+xscSMEFT.cc
+E. Jackson Wallace (ejw108@pitt.edu)
+last revision: 6 May 2026
+-------------------------------------------------------------------------------
+matrix element class needed for description of cross-section at LO in the SMEFT away from Z pole
+-----------------------------------------------------------------------------*/
+
+#include "xscSMEFT.h"
+#include "ff0.h"
+#include "ff.h"
+
+namespace griffin {
+
+double mat_SMEFTLO::resoff4f(void) const
+{
+  double fourFmats =  r4fSMEFT(it, ot, iff, off, *ival);
+  return(fourFmats);
+}
+
+Cplx mat_SMEFTLO::result(void) const
+{
+  return(mat_SMNNLO::result()+resoff4f());
+}
+
+} // namespace

--- a/xscSMEFT.h
+++ b/xscSMEFT.h
@@ -1,0 +1,26 @@
+/* xscSMEFT.h: header file for xscSMEFT.cc */
+
+#ifndef __xscSMEFT__
+#define __xscSMEFT__
+
+#include "xscnnlo.h"
+
+namespace griffin {
+
+// matrix element SMEFT (interference term off-peak)
+class mat_SMEFTLO : public mat_SMNNLO {
+public:
+  using mat_SMNNLO::mat_SMNNLO;
+
+  // corrections to off-resonance contribution: 
+  double resoff4f(void) const;  // four-fermion correction
+  Cplx resoffZ(void) const     // total
+  {
+    return(mat_SMNNLO::resoffZ()+resoff4f());
+  }
+  Cplx result(void) const;
+};
+
+} // namespace
+
+#endif // __xscSMEFT__

--- a/xscnnlo.h
+++ b/xscnnlo.h
@@ -1,5 +1,8 @@
 /* xscnnlo.h: header file for xscnnlo.cc */
 
+#ifndef __xscnnlo__
+#define __xscnnlo__
+
 #include "classes.h"
 
 namespace griffin {
@@ -32,3 +35,5 @@ public:
 };
 
 } // namespace
+
+#endif // __xscnnlo__


### PR DESCRIPTION
This code adds the ability to include the tree-level effects from the SMEFT to EWPOs, matrix elements, and the W mass shift.  In particular, it adds child classes to the SMval and invalGmu classes that allow a user to set the values of Wilson coefficients. These coefficients are then used in child classes of the SW/FA/FV/dr/mat_SMNNLO classes to calculate the tree-level SMEFT effects. It also adds some examples and some helper functions.